### PR TITLE
Output code issues without failing the build

### DIFF
--- a/src/task/RunResharperCodeAnalysisTool.ps1
+++ b/src/task/RunResharperCodeAnalysisTool.ps1
@@ -6,7 +6,8 @@ param
     [string] $additionalArguments="",
     [string] $buildId="Unlabeled_Build",
     [string] $inspectCodeResultsPathOverride,
-    [string] $resharperNugetVersion="Latest"
+    [string] $resharperNugetVersion="Latest",
+    [bool] $outputIssuesWithoutFailing=$false
 )
 
 # Gather inputs
@@ -108,12 +109,14 @@ foreach($issue in $issuesElements) {
         }
 
         $filteredElements.Add($item)
+    } elseif ($outputIssuesWithoutFailing) {
+        Write-Output ("##vso[task.logissue type={0};sourcepath={1};linenumber={2};columnnumber=1]R# {3}" -f $errorType, $issue.File, $issue.Line, $issue.Message)
     }
 }
 
 # Report results output
 
-foreach ($issue in $filteredElements | Sort-Object Severity –Descending) {
+foreach ($issue in $filteredElements | Sort-Object Severity ï¿½Descending) {
     $errorType = "warning"
     if($issue.Severity -eq "Error"){
         $errorType = "error"

--- a/src/task/RunResharperCodeAnalysisTool.ps1
+++ b/src/task/RunResharperCodeAnalysisTool.ps1
@@ -114,7 +114,7 @@ foreach($issue in $issuesElements) {
 
 # Report results output
 
-foreach ($issue in $filteredElements | Sort-Object Severity –Descending) {
+foreach ($issue in $filteredElements | Sort-Object Severity ï¿½Descending) {
     $errorType = "warning"
     if($issue.Severity -eq "Error"){
         $errorType = "error"
@@ -135,22 +135,31 @@ New-Item $summaryFilePath -type file -force
 
 $summaryMessage = ""
 
-if($filteredElements.Count -eq 0) {
-    $summaryMessage = "No code quality issues found!"
-    Write-Output ("##vso[task.complete result=Succeeded;]{0}" -f $summaryMessage)
+function Set-Results {
+    param(
+        [string]
+        $summaryMessage,
+        [ValidateSet("Succeeded", "Failed")]
+        [string]
+        $buildResult
+    )
+    Write-Output ("##vso[task.complete result={0}};]{1}" -f $buildResult, $summaryMessage)
     Add-Content $summaryFilePath ($summaryMessage)
-} elseif (-Not $failBuildOnCodeIssues) {
-    $summaryMessage = "{0} code quality issues found" -f $filteredElements.Count
-    Write-Output ("##vso[task.complete result=Succeeded;]{0}" -f $summaryMessage)
-    Add-Content $summaryFilePath ($summaryMessage)
-} elseif($filteredElements.Count -eq 1) {
-    $summaryMessage = "One code quality issue found"
-    Write-Output ("##vso[task.complete result=Failed;]{0}" -f $summaryMessage)
-    Add-Content $summaryFilePath ($summaryMessage)
+}
+
+if ($failBuildOnCodeIssues) {
+    if($filteredElements.Count -eq 0) {
+        Set-Results -summaryMessage "No code quality issues found!" -buildResult "Succeeded"
+    } elseif($filteredElements.Count -eq 1) {
+        Set-Results -summaryMessage "One code quality issue found" -buildResult "Failed"
+    } else {
+        $summaryMessage = "{0} code quality issues found" -f $filteredElements.Count
+        Write-Output ("##vso[task.complete result=Failed;]{0}" -f $summaryMessage)
+        Add-Content $summaryFilePath ("**{0}** code quality issues found" -f $filteredElements.Count)
+    }
 } else {
     $summaryMessage = "{0} code quality issues found" -f $filteredElements.Count
-    Write-Output ("##vso[task.complete result=Failed;]{0}" -f $summaryMessage)
-    Add-Content $summaryFilePath ("**{0}** code quality issues found" -f $filteredElements.Count)
+    Set-Results -summaryMessage $summaryMessage -buildResult "Succeeded"
 }
 
 Write-Output "##vso[task.addattachment type=Distributedtask.Core.Summary;name=Code Quality Analysis;]$summaryFilePath"

--- a/src/task/RunResharperCodeAnalysisTool.ps1
+++ b/src/task/RunResharperCodeAnalysisTool.ps1
@@ -3,7 +3,7 @@ param
     [string] $solutionOrProjectPath=$(throw "solutionOrProjectPath is mandatory, please provide a value."),
     [string] $commandLineInterfacePath,
     [string] $failBuildLevelSelector="Warning",
-    [bool] $outputIssuesWithoutFailing=$false,
+    [bool] $failBuildOnCodeIssues=$true,
     [string] $additionalArguments="",
     [string] $buildId="Unlabeled_Build",
     [string] $inspectCodeResultsPathOverride,
@@ -109,8 +109,6 @@ foreach($issue in $issuesElements) {
         }
 
         $filteredElements.Add($item)
-    } elseif ($outputIssuesWithoutFailing) {
-        Write-Output ("##vso[task.logissue type={0};sourcepath={1};linenumber={2};columnnumber=1]R# {3}" -f $errorType, $issue.File, $issue.Line, $issue.Message)
     }
 }
 
@@ -139,6 +137,10 @@ $summaryMessage = ""
 
 if($filteredElements.Count -eq 0) {
     $summaryMessage = "No code quality issues found!"
+    Write-Output ("##vso[task.complete result=Succeeded;]{0}" -f $summaryMessage)
+    Add-Content $summaryFilePath ($summaryMessage)
+} elseif (-Not $failBuildOnCodeIssues) {
+    $summaryMessage = "{0} code quality issues found" -f $filteredElements.Count
     Write-Output ("##vso[task.complete result=Succeeded;]{0}" -f $summaryMessage)
     Add-Content $summaryFilePath ($summaryMessage)
 } elseif($filteredElements.Count -eq 1) {

--- a/src/task/RunResharperCodeAnalysisTool.ps1
+++ b/src/task/RunResharperCodeAnalysisTool.ps1
@@ -116,7 +116,7 @@ foreach($issue in $issuesElements) {
 
 # Report results output
 
-foreach ($issue in $filteredElements | Sort-Object Severity ï¿½Descending) {
+foreach ($issue in $filteredElements | Sort-Object Severity –Descending) {
     $errorType = "warning"
     if($issue.Severity -eq "Error"){
         $errorType = "error"

--- a/src/task/RunResharperCodeAnalysisTool.ps1
+++ b/src/task/RunResharperCodeAnalysisTool.ps1
@@ -114,7 +114,7 @@ foreach($issue in $issuesElements) {
 
 # Report results output
 
-foreach ($issue in $filteredElements | Sort-Object Severity �Descending) {
+foreach ($issue in $filteredElements | Sort-Object Severity -Descending) {
     $errorType = "warning"
     if($issue.Severity -eq "Error"){
         $errorType = "error"

--- a/src/task/RunResharperCodeAnalysisTool.ps1
+++ b/src/task/RunResharperCodeAnalysisTool.ps1
@@ -3,11 +3,11 @@ param
     [string] $solutionOrProjectPath=$(throw "solutionOrProjectPath is mandatory, please provide a value."),
     [string] $commandLineInterfacePath,
     [string] $failBuildLevelSelector="Warning",
+    [bool] $outputIssuesWithoutFailing=$false,
     [string] $additionalArguments="",
     [string] $buildId="Unlabeled_Build",
     [string] $inspectCodeResultsPathOverride,
-    [string] $resharperNugetVersion="Latest",
-    [bool] $outputIssuesWithoutFailing=$false
+    [string] $resharperNugetVersion="Latest"
 )
 
 # Gather inputs

--- a/src/task/task.json
+++ b/src/task/task.json
@@ -61,7 +61,7 @@
             "label": "Fail build when Code Issues are found",
             "defaultValue": "true",
             "required": false,
-            "helpMarkDown": "If selected, the build fails if there are any Code Issue equal or above the Fail build severity.",
+            "helpMarkDown": "If selected, the build fails if there are any Code Issues equal or above the Fail build severity.",
             "groupName": "configurationOptions"
         },
         {

--- a/src/task/task.json
+++ b/src/task/task.json
@@ -56,12 +56,12 @@
             "groupName": "configurationOptions"
         },
         {
-            "name": "OutputIssuesWithoutFailing",
+            "name": "FailBuildOnCodeIssues",
             "type": "boolean",
-            "label": "Output all Code Issues without failing the build",
-            "defaultValue": "false",
+            "label": "Fail build when Code Issues are found",
+            "defaultValue": "true",
             "required": false,
-            "helpMarkDown": "If selected, all Code Issues are reported even if the build succeeds.",
+            "helpMarkDown": "If selected, the build fails if there are any Code Issue equal or above the Fail build severity.",
             "groupName": "configurationOptions"
         },
         {
@@ -105,7 +105,7 @@
     "execution": {
         "PowerShell": {
             "target": "$(currentDirectory)\\RunResharperCodeAnalysisTool.ps1",
-            "argumentFormat": "-commandLineInterfacePath $(CommandLineInterfacePath) -solutionOrProjectPath $(SolutionOrProjectPath) -failBuildLevelSelector $(FailBuildLevelSelector) -outputIssuesWithoutFailing $(OutputIssuesWithoutFailing) -additionalArguments $(AdditionalArguments) -buildId $(Build.BuildId) -inspectCodeResultsPathOverride $(ResultsOutputFilePath) -resharperNugetVersion $(ResharperNuGetVersion)",
+            "argumentFormat": "-commandLineInterfacePath $(CommandLineInterfacePath) -solutionOrProjectPath $(SolutionOrProjectPath) -failBuildLevelSelector $(FailBuildLevelSelector) -failBuildOnCodeIssues $(FailBuildOnCodeIssues) -additionalArguments $(AdditionalArguments) -buildId $(Build.BuildId) -inspectCodeResultsPathOverride $(ResultsOutputFilePath) -resharperNugetVersion $(ResharperNuGetVersion)",
             "workingDirectory": "$(currentDirectory)"
         }
     }

--- a/src/task/task.json
+++ b/src/task/task.json
@@ -105,7 +105,7 @@
     "execution": {
         "PowerShell": {
             "target": "$(currentDirectory)\\RunResharperCodeAnalysisTool.ps1",
-            "argumentFormat": "-commandLineInterfacePath $(CommandLineInterfacePath) -solutionOrProjectPath $(SolutionOrProjectPath) -failBuildLevelSelector $(FailBuildLevelSelector) -additionalArguments $(AdditionalArguments) -buildId $(Build.BuildId) -inspectCodeResultsPathOverride $(ResultsOutputFilePath) -resharperNugetVersion $(ResharperNuGetVersion)",
+            "argumentFormat": "-commandLineInterfacePath $(CommandLineInterfacePath) -solutionOrProjectPath $(SolutionOrProjectPath) -failBuildLevelSelector $(FailBuildLevelSelector) -outputIssuesWithoutFailing $(OutputIssuesWithoutFailing) -additionalArguments $(AdditionalArguments) -buildId $(Build.BuildId) -inspectCodeResultsPathOverride $(ResultsOutputFilePath) -resharperNugetVersion $(ResharperNuGetVersion)",
             "workingDirectory": "$(currentDirectory)"
         }
     }

--- a/src/task/task.json
+++ b/src/task/task.json
@@ -56,6 +56,15 @@
             "groupName": "configurationOptions"
         },
         {
+            "name": "OutputIssuesWithoutFailing",
+            "type": "boolean",
+            "label": "Output all Code Issues without failing the build",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "If selected, all Code Issues are reported even if the build succeeds.",
+            "groupName": "configurationOptions"
+        },
+        {
             "name": "CommandLineInterfacePath",
             "type": "filePath",
             "label": "Path to command line tool",


### PR DESCRIPTION
I was missing the functionality to output code issues without failing the build.

* Added a bool parameter to enable output of all code issues
