### PR TITLE
Fix for boolean string conversion

### DIFF
--- a/src/task/RunResharperCodeAnalysisTool.ps1
+++ b/src/task/RunResharperCodeAnalysisTool.ps1
@@ -147,7 +147,7 @@ New-Item $summaryFilePath -type file -force
 
 $summaryMessage = ""
 
-[bool] $failBuildOnCodeIssuesBool = Convert-String $failBuildOnCodeIssues Boolean
+[bool] $failBuildOnCodeIssuesBool = [System.Convert]::ToBoolean($failBuildOnCodeIssues)
 
 if ($failBuildOnCodeIssuesBool) {
     if($filteredElements.Count -eq 0) {

--- a/src/task/RunResharperCodeAnalysisTool.ps1
+++ b/src/task/RunResharperCodeAnalysisTool.ps1
@@ -18,7 +18,7 @@ function Set-Results {
         [string]
         $buildResult
     )
-    Write-Output ("##vso[task.complete result={0}};]{1}" -f $buildResult, $summaryMessage)
+    Write-Output ("##vso[task.complete result={0};]{1}" -f $buildResult, $summaryMessage)
     Add-Content $summaryFilePath ($summaryMessage)
 }
 

--- a/src/task/RunResharperCodeAnalysisTool.ps1
+++ b/src/task/RunResharperCodeAnalysisTool.ps1
@@ -3,7 +3,7 @@ param
     [string] $solutionOrProjectPath=$(throw "solutionOrProjectPath is mandatory, please provide a value."),
     [string] $commandLineInterfacePath,
     [string] $failBuildLevelSelector="Warning",
-    [bool] $failBuildOnCodeIssues=$true,
+    [string] $failBuildOnCodeIssues="true",
     [string] $additionalArguments="",
     [string] $buildId="Unlabeled_Build",
     [string] $inspectCodeResultsPathOverride,
@@ -147,7 +147,9 @@ New-Item $summaryFilePath -type file -force
 
 $summaryMessage = ""
 
-if ($failBuildOnCodeIssues) {
+[bool] $failBuildOnCodeIssuesBool = Convert-String $failBuildOnCodeIssues Boolean
+
+if ($failBuildOnCodeIssuesBool) {
     if($filteredElements.Count -eq 0) {
         Set-Results -summaryMessage "No code quality issues found" -buildResult "Succeeded"
     } elseif($filteredElements.Count -eq 1) {

--- a/src/task/task.json
+++ b/src/task/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 63
+        "Patch": 64
     },
     "demands": [
     ],

--- a/src/task/task.json
+++ b/src/task/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 64
+        "Patch": 65
     },
     "demands": [
     ],

--- a/src/task/task.json
+++ b/src/task/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 62
+        "Patch": 63
     },
     "demands": [
     ],

--- a/src/vss-extension.json
+++ b/src/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "resharper-code-analysis",
     "name": "Resharper Code Quality Analysis",
-    "version": "1.0.63",
+    "version": "1.0.64",
     "publisher": "alanwales",
 	"public": true,
     "targets": [

--- a/src/vss-extension.json
+++ b/src/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "resharper-code-analysis",
     "name": "Resharper Code Quality Analysis",
-    "version": "1.0.64",
+    "version": "1.0.65",
     "publisher": "alanwales",
 	"public": true,
     "targets": [

--- a/src/vss-extension.json
+++ b/src/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "resharper-code-analysis",
     "name": "Resharper Code Quality Analysis",
-    "version": "1.0.62",
+    "version": "1.0.63",
     "publisher": "alanwales",
 	"public": true,
     "targets": [


### PR DESCRIPTION
I deployed the checkbox fork but it failed because of the usual powershell quirkiness. Same issue reported here:

https://roadtoalm.com/2016/02/20/building-a-checkbox-in-your-vsts-custom-build-task/

This pull request maintains the expected string input