### PR TITLE
support StructuralSearch

### DIFF
--- a/src/task/RunResharperCodeAnalysisTool.ps1
+++ b/src/task/RunResharperCodeAnalysisTool.ps1
@@ -110,6 +110,10 @@ $filteredElements = New-Object System.Collections.Generic.List[System.Object]
 foreach($issue in $issuesElements) {
     $severity = @($issuesTypesElements | Where-Object {$_.Attributes["Id"].Value -eq $issue.Attributes["TypeId"].Value})[0].Attributes["Severity"].Value
 
+    if($severity -eq "INVALID_SEVERITY") {
+        $severity = $issue.Attributes["Severity"].Value
+    }
+
     $severityLevel = $severityLevels[$severity]
 
     if($severityLevel -ge $severityLevels[$failBuildLevelSelector]) {


### PR DESCRIPTION
This pull request enables structural search and custom code inspections. Each `StructuralSearch` issue has its own severity settings, hence the severity of this issue type is defined as `INVALID_SEVERITY`.

An example report file of inspection with structural search:
```
<?xml version="1.0" encoding="utf-8"?>
<Report ToolsVersion="112.0.20180731.143157">
  <Information>
    <Solution>test.sln</Solution>
    <InspectionScope>
      <Element>Solution</Element>
    </InspectionScope>
  </Information>
  <IssueTypes>
    <IssueType Id="StructuralSearch" Category="Structural Search Highlightings" CategoryId="StructuralSearch" Description="Structural Search Pattern" Severity="INVALID_SEVERITY" />
  </IssueTypes>
  <Issues>
    <Project Name="Tests">
      <Issue TypeId="StructuralSearch" Severity="WARNING" File="test.cs" Offset="2446-2516" Line="10" Message="Use NewMethod()" />
    </Project>
  </Issues>
</Report>
```