### PR TITLE
Workaround for hanging child processes

### DIFF
--- a/src/task/RunResharperCodeAnalysisTool.ps1
+++ b/src/task/RunResharperCodeAnalysisTool.ps1
@@ -114,7 +114,9 @@ $arguments = """$solutionOrProjectFullPath"" /o:""$inspectCodeResultsPath"" ""$a
 Write-Output "Invoking InspectCode.exe using arguments $arguments"
 
 $stdOutputFile = "./stdout.txt"
-Start-Process -FilePath $inspectCodeExePath -ArgumentList $arguments -Wait -RedirectStandardOutput $stdOutputFile
+$process = Start-Process -FilePath $inspectCodeExePath -ArgumentList $arguments -PassThru -RedirectStandardOutput $stdOutputFile
+$process.WaitForExit()
+
 if(Test-Path $stdOutputFile) {
     $stdOutputFileContent = Get-Content "$stdOutputFile"
     Write-Output $stdOutputFileContent


### PR DESCRIPTION
We are experiencing an issue with Start-Process taking about 15 minutes to complete. This is probably due to the fact that Start-Process -Wait also waits for any child processes spawned by the parent process (inspectcode) to complete. This is a workaround.